### PR TITLE
Potential fix for code scanning alert no. 2: Uncontrolled data used in path expression

### DIFF
--- a/packages/web-integration/src/playground/server.ts
+++ b/packages/web-integration/src/playground/server.ts
@@ -96,6 +96,15 @@ export default class PlaygroundServer {
 
     this.app.get('/context/:uuid', async (req, res) => {
       const { uuid } = req.params;
+
+      // Validate the UUID parameter
+      const uuidRegex = /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;
+      if (!uuidRegex.test(uuid)) {
+        return res.status(400).json({
+          error: 'Invalid UUID format',
+        });
+      }
+
       const contextFile = this.filePathForUuid(uuid);
 
       if (!existsSync(contextFile)) {


### PR DESCRIPTION
Potential fix for [https://github.com/igor-im/midscene/security/code-scanning/2](https://github.com/igor-im/midscene/security/code-scanning/2)

To fix the issue, we need to validate and sanitize the `uuid` parameter before using it to construct a file path. Since the `uuid` is expected to be a simple identifier, we can use a strict validation approach to ensure it matches a safe pattern (e.g., a UUID format or alphanumeric characters). This will prevent directory traversal attacks and ensure that only valid file paths are constructed.

Steps to fix:
1. Add a validation step for the `uuid` parameter in the `/context/:uuid` route handler.
2. Reject requests with invalid `uuid` values by returning a `400 Bad Request` response.
3. Ensure that the `uuid` is sanitized before being passed to `filePathForUuid`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
