### PR TITLE
Potential fix for code scanning alert no. 3: Uncontrolled data used in path expression

### DIFF
--- a/packages/web-integration/src/playground/server.ts
+++ b/packages/web-integration/src/playground/server.ts
@@ -96,6 +96,15 @@ export default class PlaygroundServer {
 
     this.app.get('/context/:uuid', async (req, res) => {
       const { uuid } = req.params;
+
+      // Validate that the uuid matches the expected UUID format
+      const uuidRegex = /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;
+      if (!uuidRegex.test(uuid)) {
+        return res.status(400).json({
+          error: 'Invalid UUID format',
+        });
+      }
+
       const contextFile = this.filePathForUuid(uuid);
 
       if (!existsSync(contextFile)) {


### PR DESCRIPTION
Potential fix for [https://github.com/igor-im/midscene/security/code-scanning/3](https://github.com/igor-im/midscene/security/code-scanning/3)

To fix the issue, we need to validate and sanitize the `uuid` parameter before using it to construct a file path. Since the `uuid` is expected to be a valid UUID, we can use a regular expression to ensure it matches the UUID format. This approach prevents directory traversal attacks and ensures that only valid UUIDs are used.

Steps to fix:
1. Add a validation step for the `uuid` parameter in the `/context/:uuid` route handler.
2. If the `uuid` does not match the expected format, return a `400 Bad Request` response.
3. Proceed with constructing the file path only if the `uuid` is valid.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
